### PR TITLE
Atomic Safe Memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ target_link_libraries(safe-math-test cmocka)
 target_link_libraries(safe-math-test safemathstatic)
 target_link_libraries(safe-mem-test cmocka)
 target_link_libraries(safe-mem-test safememstatic)
-
+target_link_libraries(safe-mem-test pthread)
 
 # enable testing
 enable_testing()

--- a/include/utils/safe_mem.h
+++ b/include/utils/safe_mem.h
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdatomic.h>
+#include <pthread.h>
 
 /*
     memory_object is a wrapper around a void pointer type
@@ -7,10 +9,21 @@
 */
 
 typedef struct memory_object {
-    void *data;
+    _Atomic void *data;
     bool freed;
+    pthread_mutex_t *mutex;
+    atomic_bool locked;
 } memory_object;
+
 
 
 int free_memory_object(memory_object *obj);
 memory_object new_memory_object(void *input);
+// retrieves the data object stored by memory_object
+// this allows us to safely perform operations against it
+// without worrying about concurrent access
+void *get_data_memory_object(memory_object *obj);
+// after modifying or operating with the data object
+// return it to the memory_object and unlock the mutex
+// allowing others to access it
+int put_data_memory_object(memory_object *obj, void *data);

--- a/include/utils/safe_mem.h
+++ b/include/utils/safe_mem.h
@@ -9,7 +9,7 @@
 */
 
 typedef struct memory_object {
-    _Atomic void *data;
+    void *data;
     bool freed;
     pthread_mutex_t *mutex;
     atomic_bool locked;


### PR DESCRIPTION
Make the memory_object struct atomic, allowing usage of memory_object by multi-threaded programs