### PR TITLE
Enable Writing Logs To File

### DIFF
--- a/include/utils/colors.h
+++ b/include/utils/colors.h
@@ -42,4 +42,4 @@ void print_colored(COLORS color, char *message);
   * For "sync writes" and to always flush logs to disk immediately set do_flush to true
   * returns 0 if no error, returns 1 if error
 */
-int write_colored(FILE *fh, COLORS color, char *message, bool do_flush);
+int write_colored(COLORS color, int file_descriptor, char *message);

--- a/include/utils/logger.h
+++ b/include/utils/logger.h
@@ -1,6 +1,6 @@
 /*! @file logger.h
   * @brief provides logging related functionality
-  * provides a thread safe logger capable of printing and writing colored logs
+  * provides a thread safe logger capable of printing colored logs and writing logs to disk
 */
 
 #pragma once
@@ -25,8 +25,6 @@ typedef int (*mutex_fn)(pthread_mutex_t *mx);
 /*! @brief signature used by the thread_logger for log_fn calls
 */
 typedef void (*log_fn)(struct thread_logger *thl, int file_descriptor, char *message, LOG_LEVELS level);
-
-typedef void (*write_fn)(char *message, LOG_LEVELS level);
 
 /*! @struct a thread safe logger
   * @brief guards all log calls with a mutex lock/unlock

--- a/include/utils/logger.h
+++ b/include/utils/logger.h
@@ -60,9 +60,12 @@ thread_logger *new_thread_logger(bool with_debug);
   * Calls new_thread_logger internally
 */
 file_logger *new_file_logger(char *output_file, bool with_debug);
-/*! @brief closes the opened file
+/*! @brief free resources for the threaded logger
 */
-int close_file_logger(file_logger *fhl);
+void clear_thread_logger(thread_logger *thl);
+/*! @brief free resources for the file ogger
+*/
+void clear_file_logger(file_logger *fhl);
 /*! @brief main function you should call, which will delegate to the appopriate *_log function
 */
 void log_func(thread_logger *thl,  int file_descriptor, char *message, LOG_LEVELS level);

--- a/include/utils/logger.h
+++ b/include/utils/logger.h
@@ -83,3 +83,6 @@ void error_log(thread_logger *thl,  int file_descriptor, char *message);
 /*! @brief logs an info styled message - called by log_fn
 */
 void info_log(thread_logger *thl,  int file_descriptor, char *message);
+/*! @brief used to write a log message to file
+*/
+int write_file_log(int file_descriptor, char *message);

--- a/include/utils/logger.h
+++ b/include/utils/logger.h
@@ -49,7 +49,6 @@ typedef struct thread_logger {
 typedef struct file_logger {
   thread_logger *thl;
   int file_descriptor;
-  FILE *file;
 } file_logger;
 
 /*! @brief returns a new thread safe logger

--- a/src/utils/colors.c
+++ b/src/utils/colors.c
@@ -44,7 +44,7 @@ int write_colored(COLORS color, int file_descriptor, char *message) {
     char *pcolor = get_ansi_color_scheme(color);
     char *reset = get_ansi_color_scheme(COLORS_RESET);
     // 2 for \n
-    char *write_message = malloc(strlen(pcolor) + strlen(reset) + strlen(message) + 2);
+    char *write_message = calloc(sizeof(char), strlen(pcolor) + strlen(reset) + strlen(message) + 2);
     strcat(write_message, pcolor);
     strcat(write_message, message);
     strcat(write_message, reset);

--- a/src/utils/colors.c
+++ b/src/utils/colors.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <unistd.h>
 #include "../../include/utils/colors.h"
 
 char *get_ansi_color_scheme(COLORS color) {
@@ -39,7 +40,7 @@ void print_colored(COLORS color, char *message) {
   printf("%s%s%s\n", get_ansi_color_scheme(color), message, ANSI_COLOR_RESET);
 }
 
-int write_colored(FILE *fh, COLORS color, char *message, bool do_flush) {
+int write_colored(COLORS color, int file_descriptor, char *message) {
     char *pcolor = get_ansi_color_scheme(color);
     char *reset = get_ansi_color_scheme(COLORS_RESET);
     // 2 for \n
@@ -48,23 +49,11 @@ int write_colored(FILE *fh, COLORS color, char *message, bool do_flush) {
     strcat(write_message, message);
     strcat(write_message, reset);
     strcat(write_message, "\n");
-    int response = fputs(write_message, fh);
-    if (response != 1) {
-        printf("failed to call fputs: %i\n", response);
-        free(write_message);
-        return 1; // return 1 as we return 0 if there was no error
-    }
-    // FILE* likely buffers internally so this likely doesnt cause any issues
-    // if you want to be safe set do_flush to true, but this will increase disk activity
-    if (do_flush == false) {
-        free(write_message);
+    int response = write(file_descriptor, write_message, strlen(write_message));
+    free(write_message);
+    if (response == -1) {
+        printf("failed to write colored message\n");
         return response;
     }
-    // TODO(bonedaddy): should we buffer logs?
-    response = fflush(fh);
-    if (response != 0) {
-        printf("failed to call fflush\n");
-    }
-    free(write_message);
-    return response;
+    return 0;
 }

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -2,26 +2,56 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <pthread.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include "../../include/utils/logger.h"
 
-void log_func(thread_logger *thl, char *message, LOG_LEVELS level) {
+thread_logger *new_thread_logger(bool with_debug) {
+    thread_logger *thl = malloc(sizeof(thread_logger));
+    // thl->lock = fn_mutex_lock;
+    thl->lock = pthread_mutex_lock;
+    thl->unlock = pthread_mutex_unlock;
+    thl->log = log_func;
+    thl->debug = with_debug;
+    pthread_mutex_init(&thl->mutex, NULL);
+    return thl;
+}
+
+file_logger *new_file_logger(char *output_file, bool with_debug) {
+    thread_logger *thl = new_thread_logger(with_debug);
+    file_logger *fhl = malloc(sizeof(file_logger));
+    // append to file, create if not exist, sync write files
+    // TODO(bonedaddy): try to use O_DSYNC for data integrity sync
+    int file_descriptor = open(output_file, O_WRONLY | O_CREAT);
+    if (file_descriptor <= 0) {
+        thl->log(thl, 0, "failed to run posix open function", LOG_LEVELS_ERROR);
+        return NULL;
+    }
+    fhl->file_descriptor = file_descriptor;
+    fhl->thl = thl;
+    return fhl;
+}
+
+void log_func(thread_logger *thl, int file_descriptor, char *message, LOG_LEVELS level) {
     switch (level) {
         case LOG_LEVELS_INFO:
-            info_log(thl, message);
+            info_log(thl, file_descriptor, message);
             break;
         case LOG_LEVELS_WARN:
-            warn_log(thl, message);
+            warn_log(thl, file_descriptor, message);
             break;
         case LOG_LEVELS_ERROR:
-            error_log(thl, message);
+            error_log(thl, file_descriptor, message);
             break;
         case LOG_LEVELS_DEBUG:
-            debug_log(thl, message);
+            debug_log(thl, file_descriptor, message);
             break;
     }
 }
 
-void info_log(thread_logger *thl, char *message) {
+void info_log(thread_logger *thl,  int file_descriptor, char *message) {
     thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
     char *msg = calloc(sizeof(char), strlen(message) + strlen("[info]") + (size_t)2);
@@ -33,12 +63,15 @@ void info_log(thread_logger *thl, char *message) {
     msg[5] = ']';
     msg[6] = ' ';
     strcat(msg, message);
+    if (file_descriptor != 0) {
+        write_colored(COLORS_GREEN, file_descriptor, msg);
+    }
     print_colored(COLORS_GREEN, msg);
     thl->unlock(&thl->mutex);
     free(msg);
 }
 
-void warn_log(thread_logger *thl, char *message) {
+void warn_log(thread_logger *thl, int file_descriptor, char *message) {
     thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
     char *msg = calloc(sizeof(char), strlen(message) + strlen("[warn]") + (size_t) 2);
@@ -50,12 +83,15 @@ void warn_log(thread_logger *thl, char *message) {
     msg[5] = ']';
     msg[6] = ' ';
     strcat(msg, message);
+    if (file_descriptor != 0) {
+        write_colored(COLORS_YELLOW, file_descriptor, msg);
+    }
     print_colored(COLORS_YELLOW, msg);
     thl->unlock(&thl->mutex);
     free(msg);
 }
 
-void error_log(thread_logger *thl, char *message) {
+void error_log(thread_logger *thl, int file_descriptor, char *message) {
     thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
     char *msg = calloc(sizeof(char), strlen(message) + strlen("[error]") + (size_t)2);
@@ -68,12 +104,15 @@ void error_log(thread_logger *thl, char *message) {
     msg[6] = ']';
     msg[7] = ' ';
     strcat(msg, message);
+    if (file_descriptor != 0) {
+        write_colored(COLORS_RED, file_descriptor, msg);
+    }
     print_colored(COLORS_RED, msg);
     thl->unlock(&thl->mutex);
     free(msg);
 }
 
-void debug_log(thread_logger *thl, char *message) {
+void debug_log(thread_logger *thl, int file_descriptor, char *message) {
     // unless debug enabled dont show
     if (thl->debug == false) {
         return;
@@ -90,18 +129,14 @@ void debug_log(thread_logger *thl, char *message) {
     msg[6] = ']';
     msg[7] = ' ';
     strcat(msg, message);
+    if (file_descriptor != 0) {
+        write_colored(COLORS_SOFT_RED, file_descriptor, msg);
+    }
     print_colored(COLORS_SOFT_RED, msg);
     thl->unlock(&thl->mutex);
     free(msg);
 }
 
-thread_logger *new_thread_logger(bool with_debug) {
-    thread_logger *thl = malloc(sizeof(thread_logger));
-    // thl->lock = fn_mutex_lock;
-    thl->lock = pthread_mutex_lock;
-    thl->unlock = pthread_mutex_unlock;
-    thl->log = log_func;
-    thl->debug = with_debug;
-    pthread_mutex_init(&thl->mutex, NULL);
-    return thl;
+int close_file_logger(file_logger *fhl) {
+    return close(fhl->file_descriptor);
 }

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -34,6 +34,19 @@ file_logger *new_file_logger(char *output_file, bool with_debug) {
     return fhl;
 }
 
+int write_file_log(int file_descriptor, char *message) {
+    // 2 for \n
+    char *msg = malloc(strlen(message) + 2);
+    strcat(msg, message);
+    strcat(msg, "\n");
+    int response = write(file_descriptor, msg, strlen(msg));
+    if (response == -1) {
+        printf("failed to write file log message");
+        return response;
+    }
+    return 0;
+}
+
 void log_func(thread_logger *thl, int file_descriptor, char *message, LOG_LEVELS level) {
     switch (level) {
         case LOG_LEVELS_INFO:
@@ -64,7 +77,7 @@ void info_log(thread_logger *thl,  int file_descriptor, char *message) {
     msg[6] = ' ';
     strcat(msg, message);
     if (file_descriptor != 0) {
-        write_colored(COLORS_GREEN, file_descriptor, msg);
+        write_file_log(file_descriptor, msg);
     }
     print_colored(COLORS_GREEN, msg);
     thl->unlock(&thl->mutex);
@@ -84,7 +97,7 @@ void warn_log(thread_logger *thl, int file_descriptor, char *message) {
     msg[6] = ' ';
     strcat(msg, message);
     if (file_descriptor != 0) {
-        write_colored(COLORS_YELLOW, file_descriptor, msg);
+        write_file_log(file_descriptor, msg);
     }
     print_colored(COLORS_YELLOW, msg);
     thl->unlock(&thl->mutex);
@@ -105,7 +118,7 @@ void error_log(thread_logger *thl, int file_descriptor, char *message) {
     msg[7] = ' ';
     strcat(msg, message);
     if (file_descriptor != 0) {
-        write_colored(COLORS_RED, file_descriptor, msg);
+        write_file_log(file_descriptor, msg);
     }
     print_colored(COLORS_RED, msg);
     thl->unlock(&thl->mutex);
@@ -130,7 +143,7 @@ void debug_log(thread_logger *thl, int file_descriptor, char *message) {
     msg[7] = ' ';
     strcat(msg, message);
     if (file_descriptor != 0) {
-        write_colored(COLORS_SOFT_RED, file_descriptor, msg);
+        write_file_log(file_descriptor, msg);
     }
     print_colored(COLORS_SOFT_RED, msg);
     thl->unlock(&thl->mutex);

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -140,3 +140,13 @@ void debug_log(thread_logger *thl, int file_descriptor, char *message) {
 int close_file_logger(file_logger *fhl) {
     return close(fhl->file_descriptor);
 }
+
+void clear_thread_logger(thread_logger *thl) {
+    free(thl);
+}
+
+void clear_file_logger(file_logger *fhl) {
+    close(fhl->file_descriptor);
+    clear_thread_logger(fhl->thl);
+    free(fhl);
+}

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -159,10 +159,6 @@ void debug_log(thread_logger *thl, int file_descriptor, char *message) {
     free(msg);
 }
 
-int close_file_logger(file_logger *fhl) {
-    return close(fhl->file_descriptor);
-}
-
 void clear_thread_logger(thread_logger *thl) {
     free(thl);
 }

--- a/src/utils/logger_test.c
+++ b/src/utils/logger_test.c
@@ -38,7 +38,7 @@ void test_thread_logger(void **state) {
         pthread_join(threads[i], NULL);
         pthread_attr_destroy(&attrs[i]);
     }
-    free(thl);
+    clear_thread_logger(thl);
 }
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -59,9 +59,7 @@ void test_file_logger(void **state) {
         pthread_join(threads[i], NULL);
         pthread_attr_destroy(&attrs[i]);
     }
-    close_file_logger(fhl);
-    free(fhl->thl);
-    free(fhl);
+    clear_file_logger(fhl);
 }
 
 int main(void) {

--- a/src/utils/logger_test.c
+++ b/src/utils/logger_test.c
@@ -9,8 +9,7 @@
 #include <pthread.h>
 #include "../../include/utils/logger.h"
 
-
-void *test_log(void *data) {
+void *test_thread_log(void *data) {
     thread_logger *thl = (thread_logger *)data;
     thl->log(thl, 0, "this is an info log", LOG_LEVELS_INFO);
     thl->log(thl, 0, "this is a warn log", LOG_LEVELS_WARN);
@@ -20,6 +19,18 @@ void *test_log(void *data) {
     // pthread_exit(NULL);
     return NULL;
 }
+
+void *test_file_log(void *data) {
+    file_logger *fhl = (file_logger *)data;
+    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an info log", LOG_LEVELS_INFO);
+    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a warn log", LOG_LEVELS_WARN);
+    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an error log", LOG_LEVELS_ERROR);
+    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a debug log", LOG_LEVELS_DEBUG);
+    // commenting this out seems to get rid of memleaks reported by valgrind
+    // pthread_exit(NULL);
+    return NULL;
+}
+
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 void test_thread_logger(void **state) {
@@ -32,7 +43,7 @@ void test_thread_logger(void **state) {
     pthread_attr_t attrs[4];
     for (int i = 0; i < 4; i++) {
         pthread_attr_init(&attrs[i]);
-        pthread_create(&threads[i], &attrs[i], test_log, thl);
+        pthread_create(&threads[i], &attrs[i], test_thread_log, thl);
     }
     for (int i = 0; i < 4; i++) {
         pthread_join(threads[i], NULL);
@@ -53,7 +64,7 @@ void test_file_logger(void **state) {
     pthread_attr_t attrs[4];
     for (int i = 0; i < 4; i++) {
         pthread_attr_init(&attrs[i]);
-        pthread_create(&threads[i], &attrs[i], test_log, fhl->thl);
+        pthread_create(&threads[i], &attrs[i], test_file_log, fhl);
     }
     for (int i = 0; i < 4; i++) {
         pthread_join(threads[i], NULL);

--- a/src/utils/logger_test.c
+++ b/src/utils/logger_test.c
@@ -44,7 +44,7 @@ void test_thread_logger(void **state) {
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 void test_file_logger(void **state) {
     file_logger *fhl = new_file_logger("file_logger_test.log", true);
-    printf("%i\n", fhl->file_descriptor);
+    assert(fhl != NULL);
     fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an info log", LOG_LEVELS_INFO);
     fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a warn log", LOG_LEVELS_WARN);
     fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an error log", LOG_LEVELS_ERROR);

--- a/src/utils/logger_test.c
+++ b/src/utils/logger_test.c
@@ -16,7 +16,8 @@ void *test_log(void *data) {
     thl->log(thl, "this is a warn log", LOG_LEVELS_WARN);
     thl->log(thl, "this is an error log", LOG_LEVELS_ERROR);
     thl->log(thl, "this is a debug log", LOG_LEVELS_DEBUG);
-    pthread_exit(NULL);
+    // commenting this out seems to get rid of memleaks reported by valgrind
+    // pthread_exit(NULL);
     return NULL;
 }
 
@@ -28,11 +29,14 @@ void test_thread_logger(void **state) {
     thl->log(thl, "this is an error log", LOG_LEVELS_ERROR);
     thl->log(thl, "this is a debug log", LOG_LEVELS_DEBUG);
     pthread_t threads[4];
+    pthread_attr_t attrs[4];
     for (int i = 0; i < 4; i++) {
-        pthread_create(&threads[i], NULL, test_log, thl);
+        pthread_attr_init(&attrs[i]);
+        pthread_create(&threads[i], &attrs[i], test_log, thl);
     }
     for (int i = 0; i < 4; i++) {
         pthread_join(threads[i], NULL);
+        pthread_attr_destroy(&attrs[i]);
     }
     free(thl);
 }

--- a/src/utils/logger_test.c
+++ b/src/utils/logger_test.c
@@ -12,10 +12,10 @@
 
 void *test_log(void *data) {
     thread_logger *thl = (thread_logger *)data;
-    thl->log(thl, "this is an info log", LOG_LEVELS_INFO);
-    thl->log(thl, "this is a warn log", LOG_LEVELS_WARN);
-    thl->log(thl, "this is an error log", LOG_LEVELS_ERROR);
-    thl->log(thl, "this is a debug log", LOG_LEVELS_DEBUG);
+    thl->log(thl, 0, "this is an info log", LOG_LEVELS_INFO);
+    thl->log(thl, 0, "this is a warn log", LOG_LEVELS_WARN);
+    thl->log(thl, 0, "this is an error log", LOG_LEVELS_ERROR);
+    thl->log(thl, 0, "this is a debug log", LOG_LEVELS_DEBUG);
     // commenting this out seems to get rid of memleaks reported by valgrind
     // pthread_exit(NULL);
     return NULL;
@@ -24,10 +24,10 @@ void *test_log(void *data) {
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 void test_thread_logger(void **state) {
     thread_logger *thl = new_thread_logger(true);
-    thl->log(thl, "this is an info log", LOG_LEVELS_INFO);
-    thl->log(thl, "this is a warn log", LOG_LEVELS_WARN);
-    thl->log(thl, "this is an error log", LOG_LEVELS_ERROR);
-    thl->log(thl, "this is a debug log", LOG_LEVELS_DEBUG);
+    thl->log(thl, 0, "this is an info log", LOG_LEVELS_INFO);
+    thl->log(thl, 0, "this is a warn log", LOG_LEVELS_WARN);
+    thl->log(thl, 0, "this is an error log", LOG_LEVELS_ERROR);
+    thl->log(thl, 0, "this is a debug log", LOG_LEVELS_DEBUG);
     pthread_t threads[4];
     pthread_attr_t attrs[4];
     for (int i = 0; i < 4; i++) {
@@ -41,9 +41,33 @@ void test_thread_logger(void **state) {
     free(thl);
 }
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+void test_file_logger(void **state) {
+    file_logger *fhl = new_file_logger("file_logger_test.log", true);
+    printf("%i\n", fhl->file_descriptor);
+    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an info log", LOG_LEVELS_INFO);
+    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a warn log", LOG_LEVELS_WARN);
+    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is an error log", LOG_LEVELS_ERROR);
+    fhl->thl->log(fhl->thl, fhl->file_descriptor, "this is a debug log", LOG_LEVELS_DEBUG);
+    pthread_t threads[4];
+    pthread_attr_t attrs[4];
+    for (int i = 0; i < 4; i++) {
+        pthread_attr_init(&attrs[i]);
+        pthread_create(&threads[i], &attrs[i], test_log, fhl->thl);
+    }
+    for (int i = 0; i < 4; i++) {
+        pthread_join(threads[i], NULL);
+        pthread_attr_destroy(&attrs[i]);
+    }
+    close_file_logger(fhl);
+    free(fhl->thl);
+    free(fhl);
+}
+
 int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_thread_logger),
+        cmocka_unit_test(test_file_logger),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
* Enables writing logs to file
* Writing to disk without colors is causing the following bad format to be written
```
Ðg<9e><8e>ÓU[info] this is an info log
Ðg<9e><8e>ÓU[warn] this is a warn log
Ðg<9e><8e>ÓU[error] this is an error log
Ðg<9e><8e>ÓU[debug] this is a debug log
```