### PR TITLE
Add Golang-esque Error Handling And Function Returns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ endif()
 
 include(cmake/glib.cmake)
 
+include(cmake/returns_lib.cmake)
+
 include(cmake/errors_lib.cmake)
 
 include(cmake/colors_lib.cmake)
@@ -65,6 +67,8 @@ message(STATUS "Build flags: ${flags}")
 ###############################
 
 # to disable test builds comment out `*_test()` lines
+
+define_returns_lib()
 
 define_errors_lib()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ include(cmake/returns_test.cmake)
 include(cmake/returns_lib.cmake)
 
 include(cmake/errors_lib.cmake)
+include(cmake/errors_test.cmake)
 
 include(cmake/colors_lib.cmake)
 include(cmake/colors_test.cmake)
@@ -73,6 +74,7 @@ define_returns_test()
 define_returns_lib()
 
 define_errors_lib()
+define_errors_test()
 
 define_colors_lib()
 define_colors_test()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 
 include(cmake/glib.cmake)
 
+include(cmake/returns_test.cmake)
 include(cmake/returns_lib.cmake)
 
 include(cmake/errors_lib.cmake)
@@ -68,6 +69,7 @@ message(STATUS "Build flags: ${flags}")
 
 # to disable test builds comment out `*_test()` lines
 
+define_returns_test()
 define_returns_lib()
 
 define_errors_lib()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ endif()
 
 include(cmake/glib.cmake)
 
+include(cmake/errors_lib.cmake)
+
 include(cmake/colors_lib.cmake)
 include(cmake/colors_test.cmake)
 
@@ -55,7 +57,6 @@ include(cmake/array_len_test.cmake)
 # END MACRO INCLUDES #
 ######################
 
-
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Build flags: ${flags}")
 
@@ -64,6 +65,8 @@ message(STATUS "Build flags: ${flags}")
 ###############################
 
 # to disable test builds comment out `*_test()` lines
+
+define_errors_lib()
 
 define_colors_lib()
 define_colors_test()

--- a/cmake/errors_lib.cmake
+++ b/cmake/errors_lib.cmake
@@ -1,0 +1,10 @@
+macro(define_errors_lib)
+    add_library(errorslib
+        SHARED
+            ./include/utils/errors.h
+            ./src/utils/errors.c
+    )
+    add_executable(errors-test ./src/utils/errors.c)
+    target_compile_options(errorslib PRIVATE ${flags})
+    target_link_libraries(errors-test errorslib)
+endmacro()

--- a/cmake/errors_lib.cmake
+++ b/cmake/errors_lib.cmake
@@ -4,7 +4,5 @@ macro(define_errors_lib)
             ./include/utils/errors.h
             ./src/utils/errors.c
     )
-    add_executable(errors-test ./src/utils/errors.c)
     target_compile_options(errorslib PRIVATE ${flags})
-    target_link_libraries(errors-test errorslib)
 endmacro()

--- a/cmake/errors_test.cmake
+++ b/cmake/errors_test.cmake
@@ -1,0 +1,6 @@
+macro(define_errors_test)
+    add_executable(errors-test ./src/utils/errors_test.c)
+    target_compile_options(errors-test PRIVATE ${flags})
+    target_link_libraries(errors-test errorslib)
+    target_linK_libraries(errors-test cmocka)
+endmacro()

--- a/cmake/random_lib.cmake
+++ b/cmake/random_lib.cmake
@@ -6,4 +6,6 @@ macro(define_random_lib)
             ./src/utils/random.c
     )
     target_compile_options(randomlib PRIVATE ${flags})
+    target_link_libraries(randomlib returnslib)
+    target_link_libraries(randomlib errorslib)
 endmacro()

--- a/cmake/returns_lib.cmake
+++ b/cmake/returns_lib.cmake
@@ -4,9 +4,6 @@ macro(define_returns_lib)
             ./include/utils/returns.h
             ./src/utils/returns.c
     )
-    add_executable(returns-test ./src/utils/returns.c)
     target_compile_options(returnslib PRIVATE ${flags})
     target_link_libraries(returnslib errorslib)
-    target_link_libraries(returns-test returnslib)
-    target_link_libraries(returns-test errorslib)
 endmacro()

--- a/cmake/returns_lib.cmake
+++ b/cmake/returns_lib.cmake
@@ -1,0 +1,12 @@
+macro(define_returns_lib)
+    add_library(returnslib
+        SHARED
+            ./include/utils/returns.h
+            ./src/utils/returns.c
+    )
+    add_executable(returns-test ./src/utils/returns.c)
+    target_compile_options(returnslib PRIVATE ${flags})
+    target_link_libraries(returnslib errorslib)
+    target_link_libraries(returns-test returnslib)
+    target_link_libraries(returns-test errorslib)
+endmacro()

--- a/cmake/returns_test.cmake
+++ b/cmake/returns_test.cmake
@@ -1,0 +1,7 @@
+macro(define_returns_test)
+    add_executable(returns-test ./src/utils/returns_test.c)
+    target_compile_options(returns-test PRIVATE ${flags})
+    target_link_libraries(returns-test errorslib)
+    target_link_libraries(returns-test cmocka)
+    target_link_libraries(returns-test returnslib)
+endmacro()

--- a/include/utils/errors.h
+++ b/include/utils/errors.h
@@ -15,12 +15,6 @@ typedef struct {
     char *message;
 } cg_error;
 
-typedef struct {
-    _Atomic (cg_error) *cg;
-} cg_aerror;
-
-cg_aerror *new_cg_aerror(cg_error err);
-
 /*! @brief returns a cg_error struct containing message
 */
 cg_error *new_cg_error(char *message);

--- a/include/utils/errors.h
+++ b/include/utils/errors.h
@@ -1,5 +1,5 @@
-/*! @file errors.c
-  * @brief provides a C equivalent of the golang stdlib `errors` package
+/*! @file errors.h
+  * @brief golang like error handling
 */
 
 #pragma once

--- a/include/utils/errors.h
+++ b/include/utils/errors.h
@@ -1,0 +1,37 @@
+/*! @file errors.c
+  * @brief provides a C equivalent of the golang stdlib `errors` package
+*/
+
+#pragma once
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdatomic.h>
+
+/*! @struct wraps strings into a struct with error handling functionality
+*/
+typedef struct {
+    char *message;
+} cg_error;
+
+typedef struct {
+    _Atomic (cg_error) *cg;
+} cg_aerror;
+
+cg_aerror *new_cg_aerror(cg_error err);
+
+/*! @brief returns a cg_error struct containing message
+*/
+cg_error *new_cg_error(char *message);
+/*! @brief creates a new variable and moves memory of message into that variable returning it
+  * this appears to be needed as if we dont do this `realloc` will complain about an invalid pointer
+*/
+char *cg_error_string(char *message);
+/*! @brief appends message to the end of error->message
+  * uses realloc to maximize memory efficiency
+*/
+int wrap_cg_error(cg_error *error, char *message);
+/*! @brief frees up resources associated with error
+*/
+void free_cg_error(cg_error *error);

--- a/include/utils/random.h
+++ b/include/utils/random.h
@@ -1,6 +1,8 @@
 
+#include "returns.h"
+
 int get_random_number(int lower, int upper);
-char *get_random_string(int stringLength);
+cg_return *get_random_string(int stringLength);
 
 // defines a constant character array
 const char letters[26] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};

--- a/include/utils/returns.h
+++ b/include/utils/returns.h
@@ -1,0 +1,11 @@
+#include "errors.h"
+
+typedef struct {
+    // value is the data returned by a function call (if any)
+    void *value;
+    // if not a NULL pointer than it means the function call errored
+    // and the value struct member will be a NULL pointer
+    cg_error *err;
+} cg_return;
+
+cg_return *new_cg_return(void *value, cg_error *err);

--- a/include/utils/returns.h
+++ b/include/utils/returns.h
@@ -1,5 +1,16 @@
-#include "errors.h"
+/*! @file errors.h
+  * @brief provides a C equivlent of golang function returns
+  * it enables returning two values from function call, one being an error (if any) and one being data if any
+*/
 
+#pragma once
+
+#include "errors.h"
+#include <stdlib.h>
+
+/*! @brief allows returning both a value and error message from a function call
+  * useful as it makes it easier to provid better error message and handling similar to go
+*/
 typedef struct {
     // value is the data returned by a function call (if any)
     void *value;
@@ -8,4 +19,9 @@ typedef struct {
     cg_error *err;
 } cg_return;
 
+/*! @brief creates a new cg_return struct
+*/
 cg_return *new_cg_return(void *value, cg_error *err);
+/*! @brief frees up resources associated with an instance of cg_return
+*/
+void free_cg_return(cg_return *ret);

--- a/src/utils/errors.c
+++ b/src/utils/errors.c
@@ -5,7 +5,7 @@
 #include "../../include/utils/errors.h"
 
 cg_error *new_cg_error(char *message) {
-    cg_error *err = calloc(sizeof(cg_error), sizeof(cg_error) + strlen(message));
+    cg_error *err = calloc(sizeof(cg_error), sizeof(cg_error) + strlen(message) + 1);
     err->message = cg_error_string(message);
     return err;
 }

--- a/src/utils/errors.c
+++ b/src/utils/errors.c
@@ -1,0 +1,56 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdatomic.h>
+#include "../../include/utils/errors.h"
+
+cg_error *new_cg_error(char *message) {
+    cg_error *err = calloc(sizeof(cg_error), sizeof(cg_error) + strlen(message));
+    err->message = cg_error_string(message);
+    return err;
+}
+
+char *cg_error_string(char *message) {
+    char *msg = calloc(sizeof(char), strlen(message) + 1);
+    // TODO(bonedaddy): should we use strcpy??
+    memmove(msg, message, strlen(message) + 1);
+    return msg;
+}
+
+int wrap_cg_error(cg_error *error, char *message) {
+    error->message = realloc(error->message, strlen(error->message) + strlen(message) + 1);
+    if (error->message == NULL) {
+        return -1;
+    }
+    strcat(error->message, message);
+    return 0;
+}
+
+void free_cg_error(cg_error *error) {
+    free(error->message);
+    free(error);
+}
+
+int main(void) {
+    cg_error *err = new_cg_error("hello");
+    printf("%s\n", err->message);
+    int response = wrap_cg_error(err, " world");
+    if (response == -1) {
+        printf("failed to wrap error");
+        return response;
+    }
+    printf("%s\n", err->message);
+    response = wrap_cg_error(err, " world");
+    if (response == -1) {
+        printf("failed to wrap error");
+        return response;
+    }
+    printf("%s\n", err->message);
+    response = wrap_cg_error(err, " world");
+    if (response == -1) {
+        printf("failed to wrap error");
+        return response;
+    }
+    printf("%s\n", err->message);
+    free_cg_error(err);
+}

--- a/src/utils/errors.c
+++ b/src/utils/errors.c
@@ -18,10 +18,12 @@ char *cg_error_string(char *message) {
 }
 
 int wrap_cg_error(cg_error *error, char *message) {
-    error->message = realloc(error->message, strlen(error->message) + strlen(message) + 1);
+    // 4 for delimiter of ` | `
+    error->message = realloc(error->message, strlen(error->message) + strlen(message) + 4);
     if (error->message == NULL) {
         return -1;
     }
+    strcat(error->message, " | ");
     strcat(error->message, message);
     return 0;
 }
@@ -29,28 +31,4 @@ int wrap_cg_error(cg_error *error, char *message) {
 void free_cg_error(cg_error *error) {
     free(error->message);
     free(error);
-}
-
-int main(void) {
-    cg_error *err = new_cg_error("hello");
-    printf("%s\n", err->message);
-    int response = wrap_cg_error(err, " world");
-    if (response == -1) {
-        printf("failed to wrap error");
-        return response;
-    }
-    printf("%s\n", err->message);
-    response = wrap_cg_error(err, " world");
-    if (response == -1) {
-        printf("failed to wrap error");
-        return response;
-    }
-    printf("%s\n", err->message);
-    response = wrap_cg_error(err, " world");
-    if (response == -1) {
-        printf("failed to wrap error");
-        return response;
-    }
-    printf("%s\n", err->message);
-    free_cg_error(err);
 }

--- a/src/utils/errors_test.c
+++ b/src/utils/errors_test.c
@@ -1,0 +1,51 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <assert.h>
+#include "../../include/utils/errors.h"
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+void test_new_cg_error(void **state) {
+    char *msg = "hello world";
+    cg_error *err = new_cg_error(msg);
+    assert(
+        strcmp(err->message, msg) == 0
+    );
+    free_cg_error(err);
+}
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+void test_cg_error_string(void **state) {
+    char *msg = "hello world";
+    char *errstr = cg_error_string(msg);
+    assert(
+        strcmp(errstr, "hello world") == 0
+    );
+    free(errstr);
+}
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+void test_wrap_cg_error(void **state) {
+    cg_error *err = new_cg_error("part1");
+    int response = wrap_cg_error(err, "part2");
+    assert(response == 0);
+    assert(
+        strcmp(err->message, "part1 | part2") == 0
+    );
+    free_cg_error(err);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_new_cg_error),
+        cmocka_unit_test(test_cg_error_string),
+        cmocka_unit_test(test_wrap_cg_error),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/utils/random.c
+++ b/src/utils/random.c
@@ -1,20 +1,22 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "../../include/utils/random.h"
+#include "../../include/utils/errors.h"
+#include "../../include/utils/returns.h"
 
-char *get_random_string(int stringLength) {
+cg_return *get_random_string(int stringLength) {
     // allocate a chunk of memory sized to stringLength
     // not sure why its showing an error in vscode???
     // https://stackoverflow.com/questions/50557000/complie-error-in-c-program-visual-studio-regarding-malloc-a-value-of-type-vo?rq=1
     char *retWord = malloc(stringLength);
     if (retWord == NULL) {
-        return NULL;
+        return new_cg_return(NULL, new_cg_error("failed to malloc memory"));
     }
     // assign each char from word to its corresponding vlaue in retWord
     for (int i = 0; i < stringLength; i++) {
         retWord[i] = letters[get_random_number(0, 25)];
     }
-    return retWord;
+    return new_cg_return(retWord, NULL);
 }
 
 int get_random_number(int lower, int upper) {

--- a/src/utils/random_test.c
+++ b/src/utils/random_test.c
@@ -19,6 +19,7 @@ void test_get_random_string_length(void **state) {
     assert(sizeof(word) == 8);
     assert(strlen(word) == 10);
     free(word);
+    free_cg_return(ret_val);
 }
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/src/utils/random_test.c
+++ b/src/utils/random_test.c
@@ -8,12 +8,15 @@
 #include <assert.h>
 #include "../../include/utils/random.h"
 #include "../../include/utils/array_len.h"
+#include "../../include/utils/returns.h"
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 void test_get_random_string_length(void **state) {
-    char *word = get_random_string(10);
+    cg_return *ret_val = get_random_string(10);
+    char *word = (char *)ret_val->value;
     assert(sizeof(word) == 8);
+    assert(strlen(word) == 10);
     free(word);
 }
 

--- a/src/utils/random_test.c
+++ b/src/utils/random_test.c
@@ -14,6 +14,7 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 void test_get_random_string_length(void **state) {
     cg_return *ret_val = get_random_string(10);
+    assert(ret_val->err == NULL);
     char *word = (char *)ret_val->value;
     assert(sizeof(word) == 8);
     assert(strlen(word) == 10);

--- a/src/utils/returns.c
+++ b/src/utils/returns.c
@@ -24,12 +24,3 @@ void free_cg_return(cg_return *ret) {
     }
     free(ret);
 }
-
-int main(void) {
-    int a = 1;
-    cg_error *err = new_cg_error("hello world");
-    cg_return *ret_val = new_cg_return(&a, err);
-    printf("%i\n", *(int *)ret_val->value);
-    printf("%s\n", ret_val->err->message);
-    free_cg_return(ret_val);
-}

--- a/src/utils/returns.c
+++ b/src/utils/returns.c
@@ -1,0 +1,35 @@
+#include <stdlib.h>
+#include "../../include/utils/errors.h"
+#include "../../include/utils/returns.h"
+
+cg_return *new_cg_return(void *value, cg_error *err) {
+    cg_return *ret = calloc(sizeof(cg_return), sizeof(value) + sizeof(err));
+    if (err != NULL) {
+        ret->err = err;
+    } else {
+        ret->err = NULL;
+    }
+    if (value != NULL) {
+        ret->value = value;
+    } else {
+        ret->value = NULL;
+    }
+    return ret;
+}
+
+void free_cg_return(cg_return *ret) {
+    // TODO(bonedaddy): determine how we can determine if ret->value needs to be freed
+    if (ret->err != NULL) {
+        free(ret->err);
+    }
+    free(ret);
+}
+
+int main(void) {
+    int a = 1;
+    cg_error *err = new_cg_error("hello world");
+    cg_return *ret_val = new_cg_return(&a, err);
+    printf("%i\n", *(int *)ret_val->value);
+    printf("%s\n", ret_val->err->message);
+    free_cg_return(ret_val);
+}

--- a/src/utils/returns.c
+++ b/src/utils/returns.c
@@ -20,7 +20,7 @@ cg_return *new_cg_return(void *value, cg_error *err) {
 void free_cg_return(cg_return *ret) {
     // TODO(bonedaddy): determine how we can determine if ret->value needs to be freed
     if (ret->err != NULL) {
-        free(ret->err);
+        free_cg_error(ret->err);
     }
     free(ret);
 }

--- a/src/utils/returns_test.c
+++ b/src/utils/returns_test.c
@@ -1,0 +1,47 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <assert.h>
+#include "../../include/utils/errors.h"
+#include "../../include/utils/returns.h"
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+void test_cg_return_no_error(void **state) {
+    // ensures that no error passed in results in a NULL err
+    int a = 10;
+    cg_return *ret_val = new_cg_return(&a, NULL);
+    assert(ret_val != NULL);
+    assert(ret_val->value != NULL);
+    assert(ret_val->err == NULL);
+    int *aa = (int *)ret_val->value;
+    assert(*aa == a);
+    free_cg_return(ret_val);
+}
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+void test_cg_return_error(void **state) {
+    char *msg = "thisisanerrormessage";
+    // ensures that the correct error is passed through
+    cg_error *err = new_cg_error(msg);
+    assert(err != NULL);
+    cg_return *ret_val = new_cg_return(NULL, err);
+    assert(ret_val != NULL);
+    assert(
+        strcmp(msg, ret_val->err->message) == 0
+    );
+    free_cg_return(ret_val);
+}
+
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_cg_return_no_error),
+        cmocka_unit_test(test_cg_return_error),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
* Adds a `cg_error` type that allows return error messages from functions, and wrapping existing error messages with other ones
* Adds a `cg_return` type that contains a `cg_error` and `void` pointer. This allows a function to return either an error, a value, or both.